### PR TITLE
Fixes download issue

### DIFF
--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -23,26 +23,15 @@ is also searched for a download link.</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://audacityteam.org</string>
+                <string>http://www.audacityteam.org</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;first_url&gt;http.*?dmg)</string>
+                <string>(?P&lt;url&gt;http.*?dmg)</string>
                 <key>request_headers</key>
                 <dict>
                     <!-- A Mac User-Agent is required, otherwise we get .exe links -->
                     <key>User-Agent</key>
                     <string>Mozilla/5.0 (Macintosh; Intel Mac OS X)</string>
                 </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%first_url%</string>
-                <key>re_pattern</key>
-                <string>(?P&lt;url&gt;http.*?dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The old version was giving this error:

Processing Audacity.munki...
URLTextSearcher
No match found on URL: http://audacityteam.org
Failed.
Receipt written to /Users/admin/Library/AutoPkg/Cache/local.munki.Audacity/receipts/Audacity-receipt-20151009-104424.plist

The following recipes failed:
    Audacity.munki
        Error in local.munki.Audacity: Processor: URLTextSearcher: Error: No match found on URL: http://audacityteam.org

Nothing downloaded, packaged or imported.

I chopped out the second URLTextSearcher bit, and it seems to work.

Not sure if it makes any difference, but Audacity seems not to be hosting on http://www.fosshub.com/Audacity.html