### PR TITLE
Added appcast_request_headers.

### DIFF
--- a/HopperDisassembler/HopperDisassembler3.download.recipe
+++ b/HopperDisassembler/HopperDisassembler3.download.recipe
@@ -22,6 +22,11 @@
             <dict>
                 <key>appcast_url</key>
                 <string>http://www.hopperapp.com/HopperWeb/appcast_v3.php</string>
+                <key>appcast_request_headers</key>
+                <dict>
+                    <key>User-Agent</key>
+                    <string>Hopper Disassembler</string>
+                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
* Was seeing autopkg errors lately regarding and error
  or inability to download the appcast feed. With
  a little experimentation using `curl` it looks like
  simply providing a `User-Agent` header fixes the
  problem.

(Still no https support.)