### PR TITLE
Updating new link generator path

### DIFF
--- a/Audacity/Audacity.download.recipe
+++ b/Audacity/Audacity.download.recipe
@@ -47,7 +47,7 @@ Note: the Audacity.app code object is not signed at all.</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://www.fosshub.com/genLink/%data%</string>
+                <string>http://www.fosshub.com/gensLink/%data%</string>
                 <key>re_pattern</key>
                 <string>(?P&lt;url&gt;http.*?dmg)</string>
             </dict>


### PR DESCRIPTION
They appear to still be playing with the new "features" of their download links.