### PR TITLE
modify regex - restrict to word characters

### DIFF
--- a/Cycling74/Max7.download.recipe
+++ b/Cycling74/Max7.download.recipe
@@ -24,7 +24,7 @@
                 <key>url</key>
                 <string>https://cycling74.com/thanks-for-downloading-max/?os=mac</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https://.*maxmspjitter.s3.amazonaws.com.*?dmg)</string>
+                <string>(?P&lt;url&gt;https://\w*-maxmspjitter.s3.amazonaws.com.*?dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This assumes that the string at the beginning of the URL is alphanumerical, followed by a `-`.