### PR TITLE
drop beta releases and release candidates from list of version numbers

### DIFF
--- a/HashiCorp/HashiCorpURLProvider.py
+++ b/HashiCorp/HashiCorpURLProvider.py
@@ -16,6 +16,7 @@
 
 import subprocess
 import json
+import re
 from distutils.version import LooseVersion
 
 from autopkglib import Processor, ProcessorError
@@ -26,6 +27,7 @@ __all__ = ["HashiCorpURLProvider"]
 RELEASES_BASE_URL = "https://releases.hashicorp.com"
 DEFAULT_OS = "darwin"
 DEFAULT_ARCH = "all"
+RELEASE_RE = re.compile(r'^[0-9\.]+$')
 
 
 class HashiCorpURLProvider(Processor):
@@ -59,7 +61,7 @@ class HashiCorpURLProvider(Processor):
         },
     }
     description = __doc__
-    
+
     def fetch_content(self, url, headers=None):
         """Returns content retrieved by curl, given a url and an optional
         dictionary of header-name/value mappings. Logic here borrowed from
@@ -81,7 +83,7 @@ class HashiCorpURLProvider(Processor):
             raise ProcessorError('Could not retrieve URL: %s' % url)
 
         return data
-    
+
     def download_releases_info(self, base_url):
         """Downloads the update url and returns a json object"""
         f = self.fetch_content(base_url, None)
@@ -92,23 +94,24 @@ class HashiCorpURLProvider(Processor):
             raise ProcessorError("JSON format error: %s" % e)
 
         return json_data
-    
+
     def get_project_url(self, base_url, operating_system, architecture):
         """Find and return a download URL"""
         # Download a JSON with all releases
         releases = self.download_releases_info(base_url)
         #print json.dumps(releases, sort_keys=True, indent=4, separators=(',', ': '))
-        
+
         # Sort versions with LooseVersion and get a dictionary for the latest version
         versions = releases.get('versions', None)
         version_numbers = versions.keys()
-        version_numbers.sort(key=LooseVersion, reverse=True)
-        latest_version = versions[version_numbers[0]]
+        release_numbers = [ v for v in version_numbers if RELEASE_RE.match(v) ]
+        release_numbers.sort(key=LooseVersion, reverse=True)
+        latest_version = versions[release_numbers[0]]
         #print json.dumps(latest_version, sort_keys=True, indent=4, separators=(',', ': '))
-        
+
         # Set the version variable
         self.env["version"] = latest_version.get('version', None)
-        
+
         # Go through the builds and get the os and arch specific download URL
         builds = latest_version.get('builds', [])
         found_build = next((build for build in builds if build['os'] == operating_system and build['arch'] == architecture), None)
@@ -119,7 +122,7 @@ class HashiCorpURLProvider(Processor):
             return source_url
         else:
             raise ProcessorError("No build for os: %s, arch: %s" % (operating_system, architecture))
-    
+
     def main(self):
         project_name = self.env.get("project_name")
         operating_system = self.env.get("os", DEFAULT_OS)


### PR DESCRIPTION
Drop all pre-releases from list of version numbers before retrieving the latest version, in the HashiCorpURLProvider.

This should fix the current situation where the Packer download recipe downloads 1.0.0-rc3 instead of 1.0.0. I checked a few other HashiCorp download urls, and this should work for other HashiCorp products too.