### PR TITLE
Add /Applications folder for possible pkg recipe

### DIFF
--- a/Figure53/QLab3.download.recipe
+++ b/Figure53/QLab3.download.recipe
@@ -42,7 +42,7 @@
                 <key>archive_path</key>
                 <string>%pathname%</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>
@@ -53,7 +53,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/QLab.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/QLab.app</string>
                 <key>requirement</key>
                 <string>identifier "com.figure53.QLab.3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7672N4CCJM"</string>
             </dict>


### PR DESCRIPTION
Saw there was a QLab4.pkg.recipe but no QLab3.pkg.recipe.  Tested a QLab3.pkg.recipe using the QLab4.pkg.recipe as a base and noticed that the QLab4.download.recipe had a `/Applications` for both the `destination_path` and `input_path` keys in the recipe, which this QLab3.download.recipe did not have.  Adding this allows the downloaded QLab3.app to be packaged.