### PR TITLE
modify re_pattern to fix match error

### DIFF
--- a/Go/Go.download.recipe
+++ b/Go/Go.download.recipe
@@ -24,7 +24,7 @@ Golang downloads page.</string>
                 <key>url</key>
                 <string>https://golang.org/dl/</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;https\:\/\/storage.googleapis.com\/golang\/go(?P&lt;version&gt;.*?)\.darwin-amd64.pkg)</string>
+                <string>(?P&lt;url&gt;https\:\/\/redirector.gvt1.com\/edgedl\/go\/go(?P&lt;version&gt;.*?)\.darwin-amd64.pkg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Not sure if this is a geographic thing where I get served a different
page, and not sure when this started failing, but this addresses 'No
match found on URL: https://golang.org/dl/'.