### PR TITLE
Update QLab3.munki.recipe

### DIFF
--- a/Figure53/QLab3.munki.recipe
+++ b/Figure53/QLab3.munki.recipe
@@ -44,7 +44,7 @@
             <key>Arguments</key>
             <dict>
                 <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
                 <key>dmg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
             </dict>


### PR DESCRIPTION
Thanks to @elflames for finding the solution to the error that we were experiencing: "Error in local.munki.CDU-QLab3: Processor: MunkiImporter: Error: creating pkginfo for /Users/autopkgr/Library/AutoPkg/Cache/local.munki.CDU-QLab3/QLab3.dmg failed: Could not find a supported installer item in /Users/autopkgr/Library/AutoPkg/Cache/local.munki.CDU-QLab3/QLab3.dmg!"

by adding /Applications to the dmg_root key that did resolve the issue. Thanks Tim Sutton for all your code it is greatly appreciated.