### PR TITLE
Modified url search regexp to allow for https scheme

### DIFF
--- a/KomodoEdit/KomodoEdit.download.recipe
+++ b/KomodoEdit/KomodoEdit.download.recipe
@@ -24,7 +24,7 @@
                 <key>url</key>
                 <string>https://www.activestate.com/komodo-ide/downloads/edit</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;http://.*?Komodo-Edit.*?dmg)</string>
+                <string>(?P&lt;url&gt;https?://.*?Komodo-Edit.*?dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
This extremely minor change to the regexp pattern looking for the download URL of the KomodoEdit installer dmg file should help when the scheme is "https://" rather than strictly "http://".