### PR TITLE
update go expected authority name

### DIFF
--- a/Go/Go.download.recipe
+++ b/Go/Go.download.recipe
@@ -44,7 +44,7 @@ Golang downloads page.</string>
                 <string>%pathname%</string>
                 <key>expected_authority_names</key>
                 <array>
-                    <string>Developer ID Installer: Google, Inc. (EQHXZ8M8AV)</string>
+                    <string>Developer ID Installer: Google LLC (EQHXZ8M8AV)</string>
                     <string>Developer ID Certification Authority</string>
                     <string>Apple Root CA</string>
                 </array>


### PR DESCRIPTION
quite a while back Google rebranded and since then was renamed from Inc. to LLC.
Apparently Go had been signing with the older certificate which still carried the old name, but I bet the cert expired so they started signing with the new cert at Go. Just a hunch.

Please accept my humble pull request.