### PR TITLE
Fixed url regex.

### DIFF
--- a/KomodoEdit/KomodoEdit.download.recipe
+++ b/KomodoEdit/KomodoEdit.download.recipe
@@ -24,7 +24,7 @@
                 <key>url</key>
                 <string>https://www.activestate.com/komodo-ide/downloads/edit</string>
                 <key>re_pattern</key>
-                <string>(?P&lt;url&gt;http://.*?Komodo-Edit.*?dmg)</string>
+                <string>EXE.*dl=(?P&lt;url&gt;https://.*?Komodo-Edit.*?dmg)</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
The download page must've changed, so the download recipe broke. This small change to the regex appears to have fixed it. Thanks.