### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Blackmagic/BlackMagicURLProvider.py
+++ b/Blackmagic/BlackMagicURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for BlackMagicURLProvider class"""
 
+from __future__ import absolute_import
 import json
 import re
 import urllib2
@@ -97,7 +98,7 @@ class BlackMagicURLProvider(Processor):
         try:
             metadata = urllib2.urlopen(DOWNLOADS_URL).read()
             json_data = json.loads(metadata)
-        except urllib2.HTTPError, ValueError:
+        except urllib2.HTTPError as ValueError:
             raise ProcessorError("Could not parse downloads metadata.")
         return json_data
 

--- a/Blackmagic/BlackMagicURLProvider.py
+++ b/Blackmagic/BlackMagicURLProvider.py
@@ -16,13 +16,12 @@
 """See docstring for BlackMagicURLProvider class"""
 
 from __future__ import absolute_import
+
 import json
 import re
 import urllib2
-
-from distutils.version import LooseVersion, StrictVersion
+from distutils.version import LooseVersion
 from operator import itemgetter
-from pprint import pprint
 
 from autopkglib import Processor, ProcessorError
 

--- a/DCP-o-matic/DCPomaticDownloadInfoProvider.py
+++ b/DCP-o-matic/DCPomaticDownloadInfoProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 from urllib import quote
 

--- a/DCP-o-matic/DCPomaticDownloadInfoProvider.py
+++ b/DCP-o-matic/DCPomaticDownloadInfoProvider.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 from urllib import quote
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["DCPomaticDownloadInfoProvider"]
 

--- a/HairerSoft/HairerSoftUpdateInfoProvider.py
+++ b/HairerSoft/HairerSoftUpdateInfoProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import plistlib
 import urllib2
 

--- a/HairerSoft/HairerSoftUpdateInfoProvider.py
+++ b/HairerSoft/HairerSoftUpdateInfoProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import plistlib
 
 from autopkglib import Processor, ProcessorError

--- a/HairerSoft/HairerSoftUpdateInfoProvider.py
+++ b/HairerSoft/HairerSoftUpdateInfoProvider.py
@@ -53,7 +53,7 @@ class HairerSoftUpdateInfoProvider(Processor):
             urlfd = urlopen(url)
             plist_data = urlfd.read()
             urlfd.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Could not download HairerSoft metadata plist, error: %s" % e)
 
         httpcode = urlfd.getcode()
@@ -63,7 +63,7 @@ class HairerSoftUpdateInfoProvider(Processor):
 
         try:
             plist = plistlib.readPlistFromString(plist_data)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Error parsing metadata plist! Error: %s" % e)
 
         return plist

--- a/HairerSoft/HairerSoftUpdateInfoProvider.py
+++ b/HairerSoft/HairerSoftUpdateInfoProvider.py
@@ -16,9 +16,13 @@
 
 from __future__ import absolute_import
 import plistlib
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["HairerSoftUpdateInfoProvider"]
 
@@ -45,7 +49,7 @@ class HairerSoftUpdateInfoProvider(Processor):
     def get_meta_plist(self, product_name):
         url = BASE_URL + product_name + ".plist"
         try:
-            urlfd = urllib2.urlopen(url)
+            urlfd = urlopen(url)
             plist_data = urlfd.read()
             urlfd.close()
         except BaseException as e:

--- a/HashiCorp/HashiCorpURLProvider.py
+++ b/HashiCorp/HashiCorpURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import subprocess
 import json
 import re

--- a/HashiCorp/HashiCorpURLProvider.py
+++ b/HashiCorp/HashiCorpURLProvider.py
@@ -100,7 +100,7 @@ class HashiCorpURLProvider(Processor):
         """Find and return a download URL"""
         # Download a JSON with all releases
         releases = self.download_releases_info(base_url)
-        #print json.dumps(releases, sort_keys=True, indent=4, separators=(',', ': '))
+        # print(json.dumps(releases, sort_keys=True, indent=4, separators=(',', ': ')))
 
         # Sort versions with LooseVersion and get a dictionary for the latest version
         versions = releases.get('versions', None)
@@ -108,7 +108,7 @@ class HashiCorpURLProvider(Processor):
         release_numbers = [ v for v in version_numbers if RELEASE_RE.match(v) ]
         release_numbers.sort(key=LooseVersion, reverse=True)
         latest_version = versions[release_numbers[0]]
-        #print json.dumps(latest_version, sort_keys=True, indent=4, separators=(',', ': '))
+        # print(json.dumps(latest_version, sort_keys=True, indent=4, separators=(',', ': ')))
 
         # Set the version variable
         self.env["version"] = latest_version.get('version', None)

--- a/HashiCorp/HashiCorpURLProvider.py
+++ b/HashiCorp/HashiCorpURLProvider.py
@@ -15,13 +15,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import subprocess
+
 import json
 import re
+import subprocess
 from distutils.version import LooseVersion
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["HashiCorpURLProvider"]
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib.quote` in DCPomaticDownloadInfoProvider and handling HTTP headers in BlackMagicURLProvider), but this should catch the low-hanging fruit right now.