### PR TITLE
Add CodeSignatureVerifier to iStopMotion, and AmadeusLite/Pro

### DIFF
--- a/Boinx/iStopMotion3.download.recipe
+++ b/Boinx/iStopMotion3.download.recipe
@@ -69,6 +69,30 @@ returns a Sparkle feed.</string>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+                <key>requirement</key>
+                <string>identifier "com.boinx.iStopMotion3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "6372P8EH2J"</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Boinx/iStopMotion3.munki.recipe
+++ b/Boinx/iStopMotion3.munki.recipe
@@ -36,19 +36,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>

--- a/HairerSoft/AmadeusLite.download.recipe
+++ b/HairerSoft/AmadeusLite.download.recipe
@@ -16,15 +16,15 @@
     <string>0.2.0</string>
     <key>Process</key>
     <array>
-<dict>
-    <key>Processor</key>
-    <string>HairerSoftUpdateInfoProvider</string>
-    <key>Arguments</key>
-    <dict>
-        <key>product_name</key>
-        <string>AmadeusLite</string>
-    </dict>
-</dict>
+        <dict>
+            <key>Processor</key>
+            <string>HairerSoftUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>product_name</key>
+                <string>AmadeusLite</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -32,6 +32,26 @@
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+                <key>requirement</key>
+                <string>identifier "com.HairerSoft.AmadeusLite" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FWDH9W45C2</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/HairerSoft/AmadeusLite.munki.recipe
+++ b/HairerSoft/AmadeusLite.munki.recipe
@@ -37,15 +37,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-            </dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>dmg_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>dmg_path</key>

--- a/HairerSoft/AmadeusPro2.download.recipe
+++ b/HairerSoft/AmadeusPro2.download.recipe
@@ -16,15 +16,15 @@
     <string>0.2.0</string>
     <key>Process</key>
     <array>
-<dict>
-    <key>Processor</key>
-    <string>HairerSoftUpdateInfoProvider</string>
-    <key>Arguments</key>
-    <dict>
-        <key>product_name</key>
-        <string>AmadeusPro2</string>
-    </dict>
-</dict>
+        <dict>
+            <key>Processor</key>
+            <string>HairerSoftUpdateInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>product_name</key>
+                <string>AmadeusPro2</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
@@ -32,6 +32,26 @@
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+            </dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+                <key>requirement</key>
+                <string>identifier "com.HairerSoft.AmadeusPro" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = FWDH9W45C2</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/HairerSoft/AmadeusPro2.munki.recipe
+++ b/HairerSoft/AmadeusPro2.munki.recipe
@@ -37,15 +37,6 @@
         <dict>
             <key>Arguments</key>
             <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-            </dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-        </dict>
-        <dict>
-            <key>Arguments</key>
-            <dict>
                 <key>dmg_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>dmg_path</key>


### PR DESCRIPTION
In each instance, unarchiver processor step moved from .munki recipe to .download in order to facilitate code signature verification. Minor formatting fixes to Amadeus download recipes.