### PR TITLE
AutoPkg 2 / Python 3 updates for HairerSoft recipes

### DIFF
--- a/HairerSoft/AmadeusLite.download.recipe
+++ b/HairerSoft/AmadeusLite.download.recipe
@@ -13,7 +13,7 @@
         <string>AmadeusLite</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/HairerSoft/AmadeusLite.munki.recipe
+++ b/HairerSoft/AmadeusLite.munki.recipe
@@ -29,7 +29,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0</string>
     <key>ParentRecipe</key>
     <string>com.github.timsutton.download.AmadeusLite</string>
     <key>Process</key>

--- a/HairerSoft/AmadeusPro2.download.recipe
+++ b/HairerSoft/AmadeusPro2.download.recipe
@@ -13,7 +13,7 @@
         <string>AmadeusPro2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/HairerSoft/AmadeusPro2.munki.recipe
+++ b/HairerSoft/AmadeusPro2.munki.recipe
@@ -29,7 +29,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0</string>
     <key>ParentRecipe</key>
     <string>com.github.timsutton.download.AmadeusPro2</string>
     <key>Process</key>

--- a/HairerSoft/HairerSoftUpdateInfoProvider.py
+++ b/HairerSoft/HairerSoftUpdateInfoProvider.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2014 Timothy Sutton
+# Copyright 2014-2020 Timothy Sutton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,21 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import plistlib
+from urllib.request import urlopen
+
+import certifi
 
 from autopkglib import Processor, ProcessorError
 
-try:
-    from urllib.parse import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
-
 __all__ = ["HairerSoftUpdateInfoProvider"]
 
-BASE_URL = "http://www.hairersoft.com/Downloads/"
-VALID_PRODUCTS = ['AmadeusPro2', 'AmadeusLite']
+BASE_URL = "https://www.hairersoft.com/Downloads/"
+VALID_PRODUCTS = ["AmadeusPro2", "AmadeusLite"]
+
 
 class HairerSoftUpdateInfoProvider(Processor):
     """Downloads a URL and performs a regular expression match on the text."""
@@ -37,32 +34,31 @@ class HairerSoftUpdateInfoProvider(Processor):
         "product_name": {
             "description": "Valid app names are: %s." % ", ".join(VALID_PRODUCTS),
             "required": True,
-        },
-    }
-    output_variables = {
-        "url": {
-            "description": "Download URL."
         }
     }
+    output_variables = {"url": {"description": "Download URL."}}
 
     description = __doc__
 
     def get_meta_plist(self, product_name):
         url = BASE_URL + product_name + ".plist"
         try:
-            urlfd = urlopen(url)
+            urlfd = urlopen(url, cafile=certifi.where())
             plist_data = urlfd.read()
             urlfd.close()
         except Exception as e:
-            raise ProcessorError("Could not download HairerSoft metadata plist, error: %s" % e)
+            raise ProcessorError(
+                "Could not download HairerSoft metadata plist, error: %s" % e
+            )
 
         httpcode = urlfd.getcode()
         if httpcode != 200:
-            raise ProcessorError("Got HTTP error %s trying to download URL %s" % (
-                httpcode, url))
+            raise ProcessorError(
+                "Got HTTP error %s trying to download URL %s" % (httpcode, url)
+            )
 
         try:
-            plist = plistlib.readPlistFromString(plist_data)
+            plist = plistlib.loads(plist_data)
         except Exception as e:
             raise ProcessorError("Error parsing metadata plist! Error: %s" % e)
 
@@ -71,17 +67,21 @@ class HairerSoftUpdateInfoProvider(Processor):
     def main(self):
         product = self.env.get("product_name")
         if product not in VALID_PRODUCTS:
-            raise ProcessorError("Invalid product name '%s'! Must be one of: %s" %
-                (product, ", ".join(VALID_PRODUCTS)))
+            raise ProcessorError(
+                "Invalid product name '%s'! Must be one of: %s"
+                % (product, ", ".join(VALID_PRODUCTS))
+            )
         plist = self.get_meta_plist(product)
 
-        if "productURL" in plist.keys():
+        if "productURL" in list(plist.keys()):
             self.env["url"] = plist["productURL"]
             self.output("Got URL %s from metadata plist." % self.env["url"])
         else:
-            raise ProcessorError("Expected 'productURL' key in metadata plist, but not found!")
+            raise ProcessorError(
+                "Expected 'productURL' key in metadata plist, but not found!"
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     processor = HairerSoftUpdateInfoProvider()
     processor.execute_shell()


### PR DESCRIPTION
- use newer urlopen(), plistlib.loads
- use certify's cafile since SSL otherwise fails to validate the chain
- apply black, isort
- fixes #73