### PR TITLE
BlackMagic: py3 support, use registration info only if required for product

### DIFF
--- a/Blackmagic/BlackMagicURLProvider.py
+++ b/Blackmagic/BlackMagicURLProvider.py
@@ -152,8 +152,7 @@ class BlackMagicURLProvider(URLGetter):
 
         # if this download needs registration, or we want to register
         # otherwise, ensure we've set everything
-        if latest_prod["requiresRegistration"] or \
-                self.env.get("registration_info"):
+        if latest_prod["requiresRegistration"]:
             errormsg = ("This product requires registration. Please set all "
                         "registration information in this processor using "
                         "the 'registration_info' input variable.")

--- a/Blackmagic/BlackMagicURLProvider.py
+++ b/Blackmagic/BlackMagicURLProvider.py
@@ -140,8 +140,20 @@ class BlackMagicURLProvider(URLGetter):
             raise ProcessorError("Metadata for product is missing at the "
                                  "expected location in feed.")
 
-        # if this download needs registration, ensure we've set everything
-        if latest_prod["requiresRegistration"]:
+
+        # now build a request JSON to finally ask for the download URL
+        req_data = {
+            "country": "us",
+            "platform": "Mac OS X",
+            "product": {
+                "name": self.env["product_name"]
+            }
+        }
+
+        # if this download needs registration, or we want to register
+        # otherwise, ensure we've set everything
+        if latest_prod["requiresRegistration"] or \
+                self.env.get("registration_info"):
             errormsg = ("This product requires registration. Please set all "
                         "registration information in this processor using "
                         "the 'registration_info' input variable.")
@@ -152,17 +164,9 @@ class BlackMagicURLProvider(URLGetter):
                     if key not in self.env["registration_info"] or \
                        not self.env["registration_info"][key]:
                         raise ProcessorError(errormsg)
-
-        # now build a request JSON to finally ask for the download URL
-        req_data = {
-            "country": "us",
-            "platform": "Mac OS X",
-            "product": {
-                "name": self.env["product_name"]
-            }
-        }
-        for k in self.env["registration_info"]:
-            req_data[k] = self.env["registration_info"][k]
+            # then add the registration info to req_data
+            for k in self.env["registration_info"]:
+                req_data[k] = self.env["registration_info"][k]
         req_data = json.dumps(req_data)
 
         url = "https://www.blackmagicdesign.com/api/register/us/download/"

--- a/Blackmagic/DaVinciResolve12.download.recipe
+++ b/Blackmagic/DaVinciResolve12.download.recipe
@@ -39,7 +39,7 @@ Notably, REG_STATE and REG_COUNTRY must contain sane values:
         <string></string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Blackmagic/DaVinciResolve14.download.recipe
+++ b/Blackmagic/DaVinciResolve14.download.recipe
@@ -39,7 +39,7 @@ Notably, REG_STATE and REG_COUNTRY must contain sane values:
         <string></string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Blackmagic/DaVinciResolveLite11.download.recipe
+++ b/Blackmagic/DaVinciResolveLite11.download.recipe
@@ -37,7 +37,7 @@ Notably, REG_STATE and REG_COUNTRY must contain sane values:
         <string></string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Blackmagic/Fusion8.download.recipe
+++ b/Blackmagic/Fusion8.download.recipe
@@ -37,7 +37,7 @@ Notably, REG_STATE and REG_COUNTRY must contain sane values:
         <string></string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>2.0.0</string>
     <key>Process</key>
     <array>
         <dict>


### PR DESCRIPTION
This is a combination of #60 and #75, in one branch since that made it possible to test with a current AutoPkg version.