### PR TITLE
Updated for DaVinci17

### DIFF
--- a/Blackmagic/BlackMagicURLProvider.py
+++ b/Blackmagic/BlackMagicURLProvider.py
@@ -34,7 +34,6 @@ REQUIRED_REG_KEYS = [
     "email",
     "phone",
     "city",
-    "state",
     "country",
 ]
 
@@ -145,9 +144,7 @@ class BlackMagicURLProvider(URLGetter):
         req_data = {
             "country": "us",
             "platform": "Mac OS X",
-            "product": {
-                "name": self.env["product_name"]
-            }
+            "product": self.env["product_name"]
         }
 
         # if this download needs registration, or we want to register

--- a/Blackmagic/DaVinciResolve17.download.recipe
+++ b/Blackmagic/DaVinciResolve17.download.recipe
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads latest version of DaVinci Resolve 17.
+
+This product requires registration in order to download, so
+you _must_ override all input variables beginning with 'REG_'
+and they must contain data.
+
+Notably, REG_COUNTRY must contain sane values:
+- REG_COUNTRY is of the form 'us', 'ca', etc.
+</string>
+    <key>Identifier</key>
+    <string>com.github.timsutton.download.davinciresolve17</string>
+    <key>Input</key>
+    <dict>
+        <!-- Version 14 updates _may_ contain 'Update' in the title, but
+        we also want to avoid capturing the 'Studio Update' versions -->
+        <key>PRODUCT_NAME_PATTERN</key>
+        <string>^DaVinci Resolve (?P&lt;version&gt;17(\.\d+)*)( Update)*$</string>
+        <key>NAME</key>
+        <string>DaVinciResolve17</string>
+        <key>REG_FIRSTNAME</key>
+        <string></string>
+        <key>REG_LASTNAME</key>
+        <string></string>
+        <key>REG_EMAIL</key>
+        <string></string>
+        <key>REG_PHONE</key>
+        <string></string>
+        <key>REG_CITY</key>
+        <string></string>
+        <key>REG_COUNTRY</key>
+        <string></string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.0.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>BlackMagicURLProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>product_name_pattern</key>
+                <string>%PRODUCT_NAME_PATTERN%</string>
+                <key>product_name</key>
+                <string>DaVinci Resolve</string>
+                <key>registration_info</key>
+                <dict>
+                    <key>firstname</key>
+                    <string>%REG_FIRSTNAME%</string>
+                    <key>lastname</key>
+                    <string>%REG_LASTNAME%</string>
+                    <key>email</key>
+                    <string>%REG_EMAIL%</string>
+                    <key>phone</key>
+                    <string>%REG_PHONE%</string>
+                    <key>city</key>
+                    <string>%REG_CITY%</string>
+                    <key>country</key>
+                    <string>%REG_COUNTRY%</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.zip</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Blackmagic/DaVinciResolve17.munki.recipe
+++ b/Blackmagic/DaVinciResolve17.munki.recipe
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the most recent version of DaVinci Resolve 17 and imports into Munki.
+
+Please see directions in the download recipe about additional Input variables required for this
+recipe.
+
+Resolve also includes the CUDA driver installed via a postinstall script. It may or may not
+install, depending on whether a equivalent version of the CUDA driver exists already on the system.
+The postinstall script calls another script located within the application bundle to perform the
+actual installation. It can be found here within this recipe's CACHE_DIR (look for CUDA_VER):
+
+pkg_payload/Library/Application Support/Blackmagic Design/DaVinci Resolve/Prereqs/install.sh
+
+Even if the CUDA driver does install via the Resolve installer pkg, it should not require a
+restart, as it reloads its kext and support daemons in postinstall scripts. You may consider
+adding the CUDA driver as a separate item in Munki and adding it as a 'requires' for Resolve.
+
+One caveat with this package, is that this installer runs a script that evalutes
+the owner of /dev/console to derive a home directory, which then is configured system-wide
+as a cache location for Resolve. If this installer is run while a user is logged in, then
+this user's home will be used, and if run at the loginwindow, the root user's home will be.
+</string>
+    <key>Identifier</key>
+    <string>com.github.timsutton.munki.davinciresolve17</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>DaVinciResolve17</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>This software installs the free version of DaVinci Resolve 17 which features up to 10x faster editing performance, Fairlight audio post production, dozens of new filters and effects and more. Technical support is available via the Blackmagic Design community forums.</string>
+            <key>display_name</key>
+            <string>DaVinci Resolve 17</string>
+            <key>minimum_os_version</key>
+            <string>10.11.6</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>uninstallable</key>
+            <true/>
+            <key>uninstall_method</key>
+            <string>uninstall_script</string>
+            <key>uninstall_script</key>
+            <string>#!/bin/sh
+            # Run the uninstaller script provided with the app.
+            # Alternatively, replace this with your own version of their uninstaller.
+            # For example, their uninstaller intentionally leaves the following on the
+            # system, which you may disagree with:
+            # - /Library/Application Support/Blackmagic Design/DaVinci Resolve
+            # - /Library/Preferences/Blackmagic Design/DaVinci Resolve
+            #
+            # Their uninstaller is also executable and world-writable.
+
+            UNINSTALL_SCRIPT="/Applications/DaVinci Resolve/Uninstall Resolve.app/Contents/Resources/uninstall.sh"
+
+            [ -x "${UNINSTALL_SCRIPT}" ] || exit 1
+            "${UNINSTALL_SCRIPT}"
+            </string>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.2.9</string>
+    <key>ParentRecipe</key>
+    <string>com.github.timsutton.download.davinciresolve17</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unzip</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unzip/*.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>flat_pkg_path</key>
+                <string>%found_filename%/*.pkg</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/distpkg</string>
+            </dict>
+        </dict>
+<!-- Normally below we would extract the payload and generate an installs item for the application.
+
+        ditto bails on some files within the payload: assets within a Welcome app SASS config dir:
+        Error in com.github.timsutton.munki.davinciresolve14: Processor: PkgPayloadUnpacker: Error: extraction of /Users/tsutton/Library/AutoPkg/Cache/com.github.timsutton.munki.davinciresolve14/distpkg/Manifest.pkg/Payload with ditto failed: ditto: /Users/tsutton/Library/AutoPkg/Cache/com.github.timsutton.munki.davinciresolve14/pkg_payload//Library/Application Support/Blackmagic Design/DaVinci Resolve/DaVinci Resolve Welcome.app/Contents/Resources/html/sass/config/_animations.scss: Permission denied
+
+    So instead, we inject our own installs key and substitute in the version and cross our
+    fingers that they match the actual version defined in the app's Info.plist within the package payload.
+ -->
+<!--         <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/distpkg/Manifest.pkg/Payload</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/pkg_payload</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/pkg_payload/Applications/DaVinci Resolve/DaVinci Resolve.app</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/pkg_payload</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/DaVinci Resolve/DaVinci Resolve.app</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict> -->
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installs</key>
+                    <array>
+                        <dict>
+                            <key>CFBundleIdentifier</key>
+                            <string>com.blackmagic-design.DaVinciResolve</string>
+                            <key>CFBundleName</key>
+                            <string>DaVinci Resolve</string>
+                            <key>CFBundleShortVersionString</key>
+                            <string>%version%</string>
+                            <key>path</key>
+                            <string>/Applications/DaVinci Resolve/DaVinci Resolve.app</string>
+                            <key>type</key>
+                            <string>application</string>
+                            <key>version_comparison_key</key>
+                            <string>CFBundleShortVersionString</string>
+                        </dict>
+                    </array>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%found_filename%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
The syntax of the request URL data has changed since the previous version and was failing due to 'state' now being illegal and 'product' now being a string, not a dictionary. Credit goes to my colleague Eivind Thukkel for finding the correct data set. 