### PR TITLE
updated hashicorpurlprovider location

### DIFF
--- a/HashiCorp/Packer.download.recipe
+++ b/HashiCorp/Packer.download.recipe
@@ -19,7 +19,7 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>io.github.hjuutilainen.download.Vault/HashiCorpURLProvider</string>
+            <string>io.github.hjuutilainen.SharedProcessors/HashiCorpURLProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>arch</key>

--- a/HashiCorp/Terraform.download.recipe
+++ b/HashiCorp/Terraform.download.recipe
@@ -19,7 +19,7 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>io.github.hjuutilainen.download.Vault/HashiCorpURLProvider</string>
+            <string>io.github.hjuutilainen.SharedProcessors/HashiCorpURLProvider</string>
             <key>Arguments</key>
             <dict>
                 <key>arch</key>


### PR DESCRIPTION
Was getting this warning during our automated autopkg runs:
```
WARNING: processor path not found for processor: io.github.hjuutilainen.download.Vault/HashiCorpURLProvider
```
Point to hashicorps new proc locations: io.github.hjuutilainen.SharedProcessors/HashiCorpURLProvider fixes the issue. 