### PR TITLE
Updated Processing.download git repo and code signature.

### DIFF
--- a/Processing/Processing.download.recipe
+++ b/Processing/Processing.download.recipe
@@ -22,7 +22,7 @@
                 <key>asset_regex</key>
                 <string>.*\.zip$</string>
                 <key>github_repo</key>
-                <string>processing/processing</string>
+                <string>processing/processing4</string>
             </dict>
             <key>Processor</key>
             <string>GitHubReleasesInfoProvider</string>
@@ -56,7 +56,7 @@
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Processing.app</string>
                 <key>requirement</key>
-                <string>identifier "org.processing.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8SBRM6J77J"</string>
+                <string>identifier "org.processing.four" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8SBRM6J77J"</string>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
The latest Processing github repo has moved from [processing/processing](https://github.com/processing/processing) to [processing/processing4](https://github.com/processing/processing4)

Updated the github_repo value to the new repo and the code signature to match the new version of Processing.