### PR TITLE
Allow for ARCH input variable

### DIFF
--- a/HashiCorp/Packer.download.recipe
+++ b/HashiCorp/Packer.download.recipe
@@ -12,6 +12,8 @@
         <string>Packer</string>
         <key>PRODUCT</key>
         <string>packer</string>
+        <key>ARCH</key>
+        <string>amd64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.0</string>
@@ -23,7 +25,7 @@
             <key>Arguments</key>
             <dict>
                 <key>arch</key>
-                <string>amd64</string>
+                <string>%ARCH%</string>
                 <key>project_name</key>
                 <string>%PRODUCT%</string>
             </dict>

--- a/HashiCorp/Packer.download.recipe
+++ b/HashiCorp/Packer.download.recipe
@@ -2,42 +2,42 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the current release of Packer from http://packer.io</string>
-    <key>Identifier</key>
-    <string>com.github.timsutton.download.Packer</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>Packer</string>
-        <key>PRODUCT</key>
-        <string>packer</string>
-        <key>ARCH</key>
-        <string>amd64</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.3.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>io.github.hjuutilainen.SharedProcessors/HashiCorpURLProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>arch</key>
-                <string>%ARCH%</string>
-                <key>project_name</key>
-                <string>%PRODUCT%</string>
-            </dict>
-        </dict>
+	<key>Description</key>
+	<string>Downloads the current release of Packer from http://packer.io</string>
+	<key>Identifier</key>
+	<string>com.github.timsutton.download.Packer</string>
+	<key>Input</key>
+	<dict>
+		<key>ARCH</key>
+		<string>amd64</string>
+		<key>NAME</key>
+		<string>Packer</string>
+		<key>PRODUCT</key>
+		<string>packer</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.3.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>arch</key>
+				<string>%ARCH%</string>
+				<key>project_name</key>
+				<string>%PRODUCT%</string>
+			</dict>
+			<key>Processor</key>
+			<string>io.github.hjuutilainen.SharedProcessors/HashiCorpURLProvider</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Allow for ARCH input variable

`amd64` is left as the default for now, `arm64` is available