### PR TITLE
Depreciate KomodoEdit Recipes

### DIFF
--- a/KomodoEdit/KomodoEdit.download.recipe
+++ b/KomodoEdit/KomodoEdit.download.recipe
@@ -12,9 +12,29 @@
         <string>12</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.1</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated due to the vendor retiering the softwre title.
+
+Please see this blog post for further details https://www.activestate.com/blog/activestate-komodo-ide-now-open-source/</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>

--- a/KomodoEdit/KomodoEdit.munki.recipe
+++ b/KomodoEdit/KomodoEdit.munki.recipe
@@ -35,11 +35,31 @@ contains x.y.z.</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.0</string>
+    <string>1.1</string>
     <key>ParentRecipe</key>
     <string>com.github.timsutton.download.KomodoEdit</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated due to the vendor retiering the softwre title.
+
+Please see this blog post for further details https://www.activestate.com/blog/activestate-komodo-ide-now-open-source/</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Hi, @timsutton 

This PR depreciates the KomodoEdit recipes. Activision have now officially retired the titles, and removed any downloads from their Github repo. 

https://www.activestate.com/blog/activestate-komodo-ide-now-open-source/

Thanks

