### PR TITLE
Update Max.download.recipe

### DIFF
--- a/Cycling74/Max.download.recipe
+++ b/Cycling74/Max.download.recipe
@@ -20,7 +20,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https://\w*-maxmspjitter.s3.amazonaws.com.*?dmg)</string>
+				<string>https://downloads\.cdn\.cycling74\.com/Max[\d_]+\.dmg</string>
+				<key>result_output_var_name</key>
+				<string>url</string>
 				<key>url</key>
 				<string>https://cycling74.com/downloads</string>
 			</dict>


### PR DESCRIPTION
The download URL format has changed, so the regular expression needed to be changed. I also simplified the regex by adding the `result_output_var_name` argument to the processor and setting it to `url` to create the same result as the previous recipe (which used `?P<url>` in the regex).