### PR TITLE
Update Max8 CDN URL

### DIFF
--- a/Cycling74/Max.download.recipe
+++ b/Cycling74/Max.download.recipe
@@ -20,7 +20,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https://\w*-maxmspjitter.s3.amazonaws.com.*?dmg)</string>
+				<string>https://downloads\.cdn\.cycling74\.com/Max[\d_]+\.dmg</string>
+				<key>result_output_var_name</key>
+				<string>url</string>
 				<key>url</key>
 				<string>https://cycling74.com/downloads</string>
 			</dict>

--- a/Cycling74/Max.download.recipe
+++ b/Cycling74/Max.download.recipe
@@ -20,7 +20,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https://downloads\.cdn\.cycling74\.com/Max[\d_]+\.dmg</string>
+				<string>https://downloads\.cdn\.cycling74\.com/max8/Max[\d_]+\.dmg</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>


### PR DESCRIPTION
This includes the change from https://github.com/autopkg/timsutton-recipes/pull/108 and adds one more small change to the CDN URL I found was needed.