### PR TITLE
Resolve URLDownloader error in DaVinciResolve18.download.recipe

### DIFF
--- a/Blackmagic/DaVinciResolve18.download.recipe
+++ b/Blackmagic/DaVinciResolve18.download.recipe
@@ -32,6 +32,8 @@ Notably, REG_COUNTRY must contain sane values:
         <string></string>
         <key>REG_CITY</key>
         <string></string>
+        <key>REG_STREET</key>
+        <string></string>
         <key>REG_COUNTRY</key>
         <string></string>
     </dict>
@@ -60,6 +62,8 @@ Notably, REG_COUNTRY must contain sane values:
                     <string>%REG_PHONE%</string>
                     <key>city</key>
                     <string>%REG_CITY%</string>
+                    <key>street</key>
+                    <string>%REG_STREET%</string>
                     <key>country</key>
                     <string>%REG_COUNTRY%</string>
                 </dict>


### PR DESCRIPTION
"street" is now a required field for a successful download of DaVinci Resolve 18. Resolves issue #107.