### PR TITLE
Use arch variable for Terraform

### DIFF
--- a/HashiCorp/Terraform.download.recipe
+++ b/HashiCorp/Terraform.download.recipe
@@ -26,7 +26,7 @@
             <key>Arguments</key>
             <dict>
                 <key>arch</key>
-                <string>amd64</string>
+                <string>%ARCH%</string>
                 <key>project_name</key>
                 <string>%PRODUCT%</string>
             </dict>


### PR DESCRIPTION
The input variable was added previously but it's not passed to HashiCorpURLProvider.