### PR TITLE
Update Packer.pkg.recipe

### DIFF
--- a/HashiCorp/Packer.pkg.recipe
+++ b/HashiCorp/Packer.pkg.recipe
@@ -51,6 +51,17 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%pkgroot%/usr/local/bin/LICENSE.txt</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This adds the deletion of `LICENSE.txt` before the package is created.

Once installed in `/usr/local/bin/` the license file is not directly associated with packer and has a generic name that could be already in use at that location or easily replaced by something else.