### PR TITLE
Update Packer.munki.recipe

### DIFF
--- a/HashiCorp/Packer.munki.recipe
+++ b/HashiCorp/Packer.munki.recipe
@@ -36,6 +36,23 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/usr/local/bin/packer</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
This adds processors to build a Munki `installs` array to verify installation instead of relying on the package receipt.