### PR TITLE
Update Max.download for Max 9

### DIFF
--- a/Cycling74/Max.download.recipe
+++ b/Cycling74/Max.download.recipe
@@ -20,7 +20,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https://downloads\.cdn\.cycling74\.com/max8/Max[\d_]+\.dmg</string>
+				<string>https://downloads\.cdn\.cycling74\.com/max9/Max[\d_]+\.dmg</string>
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>


### PR DESCRIPTION
They took 6 years to move from Max 8 to Mac 9, so continuing to hardcode the major version in the regex is probably fine. :-)