### PR TITLE
Add CodeSignatureVerifier to Terraform Recipes

### DIFF
--- a/HashiCorp/Terraform.download.recipe
+++ b/HashiCorp/Terraform.download.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>Downloads the current release of Terraform from http://terraform.io
-		Use e.g. -k ARCH=arm64 to specify Apple Silicon-specific builds.</string>
+        Use e.g. -k ARCH=arm64 to specify Apple Silicon-specific builds.</string>
     <key>Identifier</key>
     <string>com.github.timsutton.download.Terraform</string>
     <key>Input</key>
@@ -13,8 +13,8 @@
         <string>Terraform</string>
         <key>PRODUCT</key>
         <string>terraform</string>
-		<key>ARCH</key>
-		<string>amd64</string>
+        <key>ARCH</key>
+        <string>amd64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.0</string>
@@ -31,13 +31,39 @@
                 <string>%PRODUCT%</string>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/pkgroot/usr/local/bin</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/pkgroot/usr/local/bin/terraform</string>
+                <key>strict_verification</key>
+                <false/>
+                <key>requirement</key>
+                <string>identifier terraform and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D38WU7D763</string>
+            </dict>
         </dict>
     </array>
 </dict>

--- a/HashiCorp/Terraform.munki.recipe
+++ b/HashiCorp/Terraform.munki.recipe
@@ -42,6 +42,17 @@ and builds a package installing it to /usr/local/bin.</string>
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/pkgroot</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/HashiCorp/Terraform.pkg.recipe
+++ b/HashiCorp/Terraform.pkg.recipe
@@ -38,6 +38,19 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%pkgroot%/usr/local/bin</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>

--- a/HashiCorp/Terraform.pkg.recipe
+++ b/HashiCorp/Terraform.pkg.recipe
@@ -38,19 +38,6 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/usr/local/bin</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Hi, @timsutton 

The Current Recipes for Terraform do not check for a Code Signature on download. This PR adds in `CodeSignatureVerifier` to check the downloaded binary. 

Additionally there is some de-tabbing on the download recipes, switching the unarchiving step to the download recipe, and PathDeleter added to the munki recipe. 

Output from a successful -vv run 
```
autopkg run -v Terraform.munki.recipe 
Looking for com.github.timsutton.pkg.Terraform...
Did not find com.github.timsutton.pkg.Terraform in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.timsutton.pkg.Terraform...
Found com.github.timsutton.pkg.Terraform in recipe map
Looking for com.github.timsutton.download.Terraform...
Found com.github.timsutton.download.Terraform in recipe map
**load_recipe time: 0.010180500015849248
Processing Terraform.munki.recipe...
WARNING: Terraform.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
io.github.hjuutilainen.SharedProcessors/HashiCorpURLProvider
HashiCorpURLProvider: Found URL https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_darwin_amd64.zip
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/downloads/terraform_1.9.8_darwin_amd64.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename terraform_1.9.8_darwin_amd64.zip
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/downloads/terraform_1.9.8_darwin_amd64.zip to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot/usr/local/bin
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification disabled...
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot/usr/local/bin/terraform: valid on disk
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot/usr/local/bin/terraform: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot/usr/local/bin/terraform: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
PkgRootCreator
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot/usr
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot/usr/local
PkgRootCreator: Created /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot/usr/local/bin
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/HashiCorp/Terraform/Terraform-1.9.8.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/HashiCorp/Terraform/Terraform-1.9.8.pkg
PathDeleter
PathDeleter: Deleted /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/pkgroot
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/receipts/Terraform.munki-receipt-20241126-165309.plist

The following packages were built:
    Identifier               Version  Pkg Path                                                                                           
    ----------               -------  --------                                                                                           
    com.hashicorp.Terraform  1.9.8    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.timsutton.munki.Terraform/Terraform-1.9.8.pkg  

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                                    Pkg Repo Path                                 Icon Repo Path  
    ----       -------  --------  ------------                                    -------------                                 --------------  
    Terraform  1.9.8    testing   apps/HashiCorp/Terraform/Terraform-1.9.8.plist  apps/HashiCorp/Terraform/Terraform-1.9.8.pkg
```