### PR TITLE
Fix REDCINE-XPRO.download recipe

### DIFF
--- a/REDCINE-XPRO/REDCINE-XPRO.download.recipe
+++ b/REDCINE-XPRO/REDCINE-XPRO.download.recipe
@@ -15,8 +15,6 @@ SPARKLE_FEED_URL could be overridden to the above if you wish to fetch beta vers
     <dict>
         <key>NAME</key>
         <string>REDCINE-XPRO</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://downloads.red.com/software/rcx/rss/mac_pkg.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
@@ -24,11 +22,28 @@ SPARKLE_FEED_URL could be overridden to the above if you wish to fetch beta vers
     <array>
         <dict>
             <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
+            <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
+                <key>re_pattern</key>
+                <string>data-name="REDCINE-X PRO \(MAC\)" data-versioninternalid="(\d+)" download=</string>
+                <key>result_output_var_name</key>
+                <string>versionid</string>
+                <key>url</key>
+                <string>https://www.red.com/download/redcine-x-pro-mac</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>re_pattern</key>
+                <string>versionUrl":"(https://downloads\.red\.com/software/rcx/mac/release/[\d\.]+/REDCINE-X_PRO_Build_[\d\.]+\.pkg)"}</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
+                <key>url</key>
+                <string>https://www.red.com/RedSuiteCentric/SCA-Kilimanjaro/services/DownloadUrl.Service.ss?internalid=%versionid%</string>
             </dict>
         </dict>
         <dict>

--- a/REDCINE-XPRO/REDCINE-XPRO.download.recipe
+++ b/REDCINE-XPRO/REDCINE-XPRO.download.recipe
@@ -54,6 +54,21 @@ SPARKLE_FEED_URL could be overridden to the above if you wish to fetch beta vers
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: RED Digital Cinema (4ER5V66EKT)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR fixes the REDCINE-XPRO download recipe, which is currently using a non-functional Sparkle feed. Instead, the recipe uses URLTextSearcher to get the pkg download URL from the download page.

Verbose recipe run output:

```
% autopkg run -vvq REDCINE-XPRO.download.recipe
Processing REDCINE-XPRO.download.recipe...
WARNING: REDCINE-XPRO.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'data-name="REDCINE-X PRO \\(MAC\\)" '
                         'data-versioninternalid="(\\d+)" download=',
           'result_output_var_name': 'versionid',
           'url': 'https://www.red.com/download/redcine-x-pro-mac'}}
URLTextSearcher: Found matching text (versionid): 1000
{'Output': {'versionid': '1000'}}
URLTextSearcher
{'Input': {'re_pattern': 'versionUrl":"(https://downloads\\.red\\.com/software/rcx/mac/release/[\\d\\.]+/REDCINE-X_PRO_Build_[\\d\\.]+\\.pkg)"}',
           'result_output_var_name': 'url',
           'url': 'https://www.red.com/RedSuiteCentric/SCA-Kilimanjaro/services/DownloadUrl.Service.ss?internalid=1000'}}
URLTextSearcher: Found matching text (url): https://downloads.red.com/software/rcx/mac/release/62.0.29/REDCINE-X_PRO_Build_62.0.29.pkg
{'Output': {'url': 'https://downloads.red.com/software/rcx/mac/release/62.0.29/REDCINE-X_PRO_Build_62.0.29.pkg'}}
URLDownloader
{'Input': {'url': 'https://downloads.red.com/software/rcx/mac/release/62.0.29/REDCINE-X_PRO_Build_62.0.29.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 23 May 2024 22:06:01 GMT
URLDownloader: Storing new ETag header: "91e21af70447a67b8fdc7aadeaac6e3d-14"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.timsutton.download.redcine-xpro/downloads/REDCINE-X_PRO_Build_62.0.29.pkg
{'Output': {'download_changed': True,
            'etag': '"91e21af70447a67b8fdc7aadeaac6e3d-14"',
            'last_modified': 'Thu, 23 May 2024 22:06:01 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.timsutton.download.redcine-xpro/downloads/REDCINE-X_PRO_Build_62.0.29.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.timsutton.download.redcine-xpro/downloads/REDCINE-X_PRO_Build_62.0.29.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: RED Digital '
                                        'Cinema (4ER5V66EKT)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.timsutton.download.redcine-xpro/downloads/REDCINE-X_PRO_Build_62.0.29.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "REDCINE-X_PRO_Build_62.0.29.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-05-23 17:40:49 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: RED Digital Cinema (4ER5V66EKT)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F7 AF BD CC 4D 05 D8 BE 65 60 0D C4 AD B8 D7 B9 AA 80 B1 92 7E 0F
CodeSignatureVerifier:            30 37 44 00 12 5F 40 CA A9 C0
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.timsutton.download.redcine-xpro/receipts/REDCINE-XPRO.download-receipt-20241228-062020.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.timsutton.download.redcine-xpro/downloads/REDCINE-X_PRO_Build_62.0.29.pkg
```
