### PR TITLE
Deprecate QLab3 recipes

### DIFF
--- a/Figure53/QLab3.download.recipe
+++ b/Figure53/QLab3.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>QLab 3 is no longer available for download. Consider switching to the QLab 4 or QLab 5 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional QLab3 recipes, since that software is no longer available for download, and points users to working QLab4 or QLab5 recipes in the dataJAR-recipes repo.
