### PR TITLE
Deprecate iTunes recipes

### DIFF
--- a/iTunes/iTunes.download.recipe
+++ b/iTunes/iTunes.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>https://www.apple.com/itunes/download/</string>
+                <string>https://support.apple.com/en-us/106374</string>
                 <key>re_pattern</key>
                 <string>https://secure.*?dmg</string>
             </dict>

--- a/iTunes/iTunes.download.recipe
+++ b/iTunes/iTunes.download.recipe
@@ -37,6 +37,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Install iTunes.pkg</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Software Update</string>
+                    <string>Apple Software Update Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/iTunes/iTunes.download.recipe
+++ b/iTunes/iTunes.download.recipe
@@ -15,6 +15,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe is deprecated and will be removed in the future. New versions of iTunes are no longer available for standalone download. This recipe provides the dmg for iTunes 12.8.3. Other versions can be found here: https://support.apple.com/en-us/docs/software/pl295</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the iTunes recipes, since new versions of iTunes for Mac are no longer being offered as standalone dmg downloads.

Also included are updates to the support URL and code signature verification, to enable the recipe to have one last victory lap.

Verbose recipe run output:

```
% autopkg run -vvq 'iTunes/iTunes.download.recipe'
Processing iTunes/iTunes.download.recipe...
WARNING: iTunes/iTunes.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
DeprecationWarning
{'Input': {'warning_message': 'This recipe is deprecated and will be removed '
                              'in the future. New versions of iTunes are no '
                              'longer available for standalone download. This '
                              'recipe provides the dmg for iTunes 12.8.3. '
                              'Other versions can be found here: '
                              'https://support.apple.com/en-us/docs/software/pl295'}}
DeprecationWarning: This recipe is deprecated and will be removed in the future. New versions of iTunes are no longer available for standalone download. This recipe provides the dmg for iTunes 12.8.3. Other versions can be found here: https://support.apple.com/en-us/docs/software/pl295
{'Output': {'deprecation_summary_result': {'data': {'name': 'iTunes.download',
                                                    'warning': 'This recipe is '
                                                               'deprecated and '
                                                               'will be '
                                                               'removed in the '
                                                               'future. New '
                                                               'versions of '
                                                               'iTunes are no '
                                                               'longer '
                                                               'available for '
                                                               'standalone '
                                                               'download. This '
                                                               'recipe '
                                                               'provides the '
                                                               'dmg for iTunes '
                                                               '12.8.3. Other '
                                                               'versions can '
                                                               'be found here: '
                                                               'https://support.apple.com/en-us/docs/software/pl295'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
URLTextSearcher
{'Input': {'re_pattern': 'https://secure.*?dmg',
           'url': 'https://support.apple.com/en-us/106374'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://secure-appldnld.apple.com/itunes12/041-56365-20210413-79A5AC6D-6B0A-46EC-B399-5A381183E3BE/iTunes12.8.3.dmg
{'Output': {'match': 'https://secure-appldnld.apple.com/itunes12/041-56365-20210413-79A5AC6D-6B0A-46EC-B399-5A381183E3BE/iTunes12.8.3.dmg'}}
URLDownloader
{'Input': {'url': 'https://secure-appldnld.apple.com/itunes12/041-56365-20210413-79A5AC6D-6B0A-46EC-B399-5A381183E3BE/iTunes12.8.3.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 13 Apr 2021 23:04:43 GMT
URLDownloader: Storing new ETag header: "cd547c2c456c2dee32fec8ce72ef5bb6"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.timsutton.download.iTunes/downloads/iTunes12.8.3.dmg
{'Output': {'download_changed': True,
            'etag': '"cd547c2c456c2dee32fec8ce72ef5bb6"',
            'last_modified': 'Tue, 13 Apr 2021 23:04:43 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.timsutton.download.iTunes/downloads/iTunes12.8.3.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.timsutton.download.iTunes/downloads/iTunes12.8.3.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Software Update',
                                        'Apple Software Update Certification '
                                        'Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.timsutton.download.iTunes/downloads/iTunes12.8.3.dmg/Install '
                         'iTunes.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.timsutton.download.iTunes/downloads/iTunes12.8.3.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install iTunes.pkg":
CodeSignatureVerifier:    Status: signed Apple Software
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Software Update
CodeSignatureVerifier:        Expires: 2029-04-14 21:28:23 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66
CodeSignatureVerifier:            80 28 92 05 83 B1 E8 96 EB B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Apple Software Update Certification Authority
CodeSignatureVerifier:        Expires: 2031-10-15 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D
CodeSignatureVerifier:            D1 85 0B 82 74 F3 5C 71 74 5C
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.timsutton.download.iTunes/receipts/iTunes.download-receipt-20241228-055625.plist

The following recipes have deprecation warnings:
    Name             Warning
    ----             -------
    iTunes.download  This recipe is deprecated and will be removed in the future. New versions of iTunes are no longer available for standalone download. This recipe provides the dmg for iTunes 12.8.3. Other versions can be found here: https://support.apple.com/en-us/docs/software/pl295

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.timsutton.download.iTunes/downloads/iTunes12.8.3.dmg
```
