### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/HopperDisassembler/HopperDisassembler2.download.recipe
+++ b/HopperDisassembler/HopperDisassembler2.download.recipe
@@ -21,7 +21,7 @@
             <key>Arguments</key>
             <dict>
                 <key>appcast_url</key>
-                <string>http://www.hopperapp.com/HopperWeb/appcast.php</string>
+                <string>https://www.hopperapp.com/HopperWeb/appcast.php</string>
             </dict>
         </dict>
         <dict>

--- a/RogueAmoeba/Fission2.download.recipe
+++ b/RogueAmoeba/Fission2.download.recipe
@@ -29,7 +29,7 @@ later revisions will require a higher OS, so this may be overridden.
             <key>Arguments</key>
             <dict>
                 <key>alternate_xmlns_url</key>
-                <string>http://rogueamoeba.com/public/rss/sparkle/</string>
+                <string>https://rogueamoeba.com/public/rss/sparkle/</string>
                 <key>appcast_url</key>
                 <string>https://rogueamoeba.net/ping/versionCheck.cgi</string>
                 <key>appcast_query_pairs</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._