### PR TITLE
Deprecate DCPomatic2 recipes

### DIFF
--- a/DCP-o-matic/DCPomatic2.download.recipe
+++ b/DCP-o-matic/DCPomatic2.download.recipe
@@ -28,9 +28,18 @@ CHANNEL can be either 'stable' or 'test'
         <string>DCPomatic2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.3.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to DCPomatic2 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>DCPomaticDownloadInfoProvider</string>


### PR DESCRIPTION
Per the AutoPkg [repo maintenance expectations](https://github.com/autopkg/autopkg/wiki/Sharing-Recipes#repo-maintenance-expectations), duplicate recipes can appear in search results and cause confusion, especially for people getting started with AutoPkg. Consolidating in favor of recipes with the broadest utility helps reduce that noise.

The [DCP-o-matic 2 download recipe in dataJAR-recipes](https://github.com/autopkg/dataJAR-recipes/blob/master/DCP-o-matic%202/DCP-o-matic%202.download.recipe) is a more broadly useful alternative to this repo's recipe:
- **Has CodeSignatureVerifier** — verifies the downloaded app's code signature for added security; this recipe does not

This consolidation will help simplify search results and lower maintenance effort. Thank you for considering!